### PR TITLE
Update README to use Webpack 2+ syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With this configuration:
 ```javascript
 {
     module: {
-      loaders: [
+      rules: [
         { test: /\.mjml$/, loader: 'mjml-loader' }
       ]
     }


### PR DESCRIPTION
Webpack 2 onwards uses `module.rules` instead of `module.loaders`.